### PR TITLE
Add user_properties to test report

### DIFF
--- a/pytest_elk_reporter.py
+++ b/pytest_elk_reporter.py
@@ -197,6 +197,7 @@ class ElkReporter(object):  # pylint: disable=too-many-instance-attributes
     def report_test(self, item_report, outcome, old_report=None):
         self.stats[outcome] += 1
         test_data = dict(
+            item_report.user_properties,
             timestamp=datetime.datetime.utcnow().isoformat(),
             name=item_report.nodeid,
             outcome=outcome,

--- a/tests/test_elk_reporter.py
+++ b/tests/test_elk_reporter.py
@@ -428,7 +428,6 @@ def test_marker_collection(
     assert "mark2" in second_report["markers"]
 
 
-<<<<<<< HEAD
 def test_xdist(testdir, requests_mock):  # pylint: disable=redefined-outer-name
     # create a temporary pytest test module
     testdir.makepyfile(
@@ -467,7 +466,7 @@ def test_user_properties(
         """
         import pytest
 
-|        def test_1(record_property):
+        def test_1(record_property):
             record_property("example_key", 1)
             pass
         """

--- a/tests/test_elk_reporter.py
+++ b/tests/test_elk_reporter.py
@@ -428,6 +428,7 @@ def test_marker_collection(
     assert "mark2" in second_report["markers"]
 
 
+<<<<<<< HEAD
 def test_xdist(testdir, requests_mock):  # pylint: disable=redefined-outer-name
     # create a temporary pytest test module
     testdir.makepyfile(
@@ -458,7 +459,10 @@ def test_xdist(testdir, requests_mock):  # pylint: disable=redefined-outer-name
             assert "mark2" in report["markers"]
 
 
-def test_user_properties(testdir, requests_mock):
+def test_user_properties(
+    testdir, requests_mock
+):
+    # create a temporary pytest test module
     testdir.makepyfile(
         """
         import pytest

--- a/tests/test_elk_reporter.py
+++ b/tests/test_elk_reporter.py
@@ -461,7 +461,7 @@ def test_xdist(testdir, requests_mock):  # pylint: disable=redefined-outer-name
 
 def test_user_properties(
     testdir, requests_mock
-):
+):  # pylint: disable=redefined-outer-name
     # create a temporary pytest test module
     testdir.makepyfile(
         """


### PR DESCRIPTION
Other reporting plugins allow user properties to be published using the builtin record_property fixture.  This PR publishes the user_properties to elastic search with the test report