### PR TITLE
feature(slices): split test based on history of run durations

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    this_marker:  used for testing markers

--- a/pytest_elk_reporter.py
+++ b/pytest_elk_reporter.py
@@ -362,13 +362,7 @@ class ElkReporter(object):  # pylint: disable=too-many-instance-attributes
         print("clear old exclude files")
         # Get a list of all files in directory
         for root_dir, _, filenames in os.walk(outputdir):
-            # Find the files that matches the given patterm
-            for filename in fnmatch.filter(filenames, "exclude_*.txt"):
-                try:
-                    os.remove(os.path.join(root_dir, filename))
-                except OSError:
-                    print(f"Error while deleting file {filename}")
-
+            # Find the files that matches the given pattern
             for filename in fnmatch.filter(filenames, "include_*.txt"):
                 try:
                     os.remove(os.path.join(root_dir, filename))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,47 @@
+import re
+
+import pytest
+import requests_mock as rm_module
+
+
 pytest_plugins = "pytester"  # pylint: disable=invalid-name
+
+
+@pytest.fixture(scope="function")  # executed on every test
+def requests_mock():
+    """Mock out the requests component of your code with defined responses.
+    Mocks out any requests made through the python requests library with useful
+    responses for unit testing. See:
+    https://requests-mock.readthedocs.io/en/latest/
+    """
+    kwargs = {"real_http": False}
+
+    with rm_module.Mocker(**kwargs) as mock:
+        yield mock
+
+
+@pytest.fixture(scope="function", autouse=True)
+def configure_es_mock(requests_mock):  # pylint: disable=redefined-outer-name
+    matcher = re.compile(r"http://127.0.0.1:9200/test_data/.*")
+    requests_mock.post(
+        matcher,
+        response_list=[
+            dict(
+                text='{"aggregations": {"percentiles_duration": {"values": {"95.0": 60.0}}}}',
+                status_code=201,
+            ),
+            dict(
+                text='{"aggregations": {"percentiles_duration": {"values": {"95.0": 60.0}}}}',
+                status_code=201,
+            ),
+            dict(
+                text='{"aggregations": {"percentiles_duration": {"values": {"95.0": 120.0}}}}',
+                status_code=201,
+            ),
+            dict(
+                text='{"aggregations": {"percentiles_duration": {"values": {"95.0": null}}}}',
+                status_code=201,
+            ),
+            dict(text="should error !!!", status_code=500),
+        ],
+    )

--- a/tests/test_elk_reporter.py
+++ b/tests/test_elk_reporter.py
@@ -1,44 +1,9 @@
 # -*- coding: utf-8 -*-
 
 import os
-import re
 import json
 
 import pytest
-import requests_mock as rm_module
-
-try:
-    from distutils import version  # pylint: disable=no-name-in-module
-
-    _PYTEST_VERSION = version.StrictVersion(pytest.__version__)
-    _PYTEST_30 = _PYTEST_VERSION >= version.StrictVersion("3.0.0")
-except Exception:  # pylint: disable=broad-except
-    _PYTEST_30 = False
-
-if _PYTEST_30:
-    _FIXTRUE_TYPE = pytest.fixture
-else:
-    _FIXTRUE_TYPE = pytest.yield_fixture
-
-
-@_FIXTRUE_TYPE(scope="function")  # executed on every test
-def requests_mock():
-    """Mock out the requests component of your code with defined responses.
-    Mocks out any requests made through the python requests library with useful
-    responses for unit testing. See:
-    https://requests-mock.readthedocs.io/en/latest/
-    """
-    kwargs = {"real_http": False}
-
-    with rm_module.Mocker(**kwargs) as mock:
-        yield mock
-
-
-@pytest.fixture(scope="function", autouse=True)
-def configure_es_mock(requests_mock):  # pylint: disable=redefined-outer-name
-    matcher = re.compile(r"http://127.0.0.1:9200/.*")
-    # requests_mock.post(matcher, text="data", status_code=201, real_http=True)
-    requests_mock.post(matcher, real_http=True)
 
 
 def test_failures(testdir, requests_mock):  # pylint: disable=redefined-outer-name

--- a/tests/test_slices.py
+++ b/tests/test_slices.py
@@ -36,18 +36,25 @@ def test_history_slices(testdir):
 
     # corresponding slice files, should exist
     with open(testdir.tmpdir / "include_000.txt") as slice_file:
-        assert set(slice_file.read().splitlines()) == set(
-            [
-                "test_history_slices.py::test_should_pass_1",
-                "test_history_slices.py::test_should_pass_2",
-                "test_history_slices.py::test_should_pass_3",
-            ]
-        )
+        test_set_one = set(slice_file.read().splitlines())
 
     with open(testdir.tmpdir / "include_001.txt") as slice_file:
-        assert set(slice_file.read().splitlines()) == set(
-            [
-                "test_history_slices.py::test_with_history_data",
-                "test_history_slices.py::test_that_failed",
-            ]
-        )
+        test_set_two = set(slice_file.read().splitlines())
+
+    assert test_set_one | test_set_two == {
+        "test_history_slices.py::test_should_pass_1",
+        "test_history_slices.py::test_should_pass_2",
+        "test_history_slices.py::test_should_pass_3",
+        "test_history_slices.py::test_with_history_data",
+        "test_history_slices.py::test_that_failed",
+    }
+
+    # run again, to make sure we clean old include*.txt files
+    result = testdir.runpytest(
+        "-v",
+        "-s",
+        "--collect-only",
+        "--es-slices",
+        "--es-max-splice-time=4",
+        "--es-address=127.0.0.1:9200",
+    )

--- a/tests/test_slices.py
+++ b/tests/test_slices.py
@@ -36,14 +36,18 @@ def test_history_slices(testdir):
 
     # corresponding slice files, should exist
     with open(testdir.tmpdir / "include_000.txt") as slice_file:
-        assert slice_file.read().splitlines() == [
-            "test_history_slices.py::test_should_pass_1",
-            "test_history_slices.py::test_should_pass_2",
-            "test_history_slices.py::test_should_pass_3",
-        ]
+        assert set(slice_file.read().splitlines()) == set(
+            [
+                "test_history_slices.py::test_should_pass_1",
+                "test_history_slices.py::test_should_pass_2",
+                "test_history_slices.py::test_should_pass_3",
+            ]
+        )
 
     with open(testdir.tmpdir / "include_001.txt") as slice_file:
-        assert slice_file.read().splitlines() == [
-            "test_history_slices.py::test_with_history_data",
-            "test_history_slices.py::test_that_failed",
-        ]
+        assert set(slice_file.read().splitlines()) == set(
+            [
+                "test_history_slices.py::test_with_history_data",
+                "test_history_slices.py::test_that_failed",
+            ]
+        )

--- a/tests/test_slices.py
+++ b/tests/test_slices.py
@@ -1,0 +1,49 @@
+def test_history_slices(testdir):
+    # create a temporary pytest test module
+    testdir.makepyfile(
+        """
+        def test_should_pass_1(elk_reporter):
+            pass
+        def test_should_pass_2(elk_reporter):
+            pass
+        def test_should_pass_3(elk_reporter):
+           pass
+        def test_with_history_data(elk_reporter):
+           pass
+        def test_that_failed(elk_reporter):
+           pass
+        """
+    )
+
+    result = testdir.runpytest(
+        "-v",
+        "-s",
+        "--collect-only",
+        "--es-slices",
+        "--es-max-splice-time=4",
+        "--es-address=127.0.0.1:9200",
+    )
+
+    # fnmatch_lines does an assertion internally
+    result.stdout.fnmatch_lines(["*Function test_should_pass_1*"])
+    assert "test_history_slices.py::test_that_failed" in str(result.stdout)
+
+    # expect two specific slices
+    result.stdout.fnmatch_lines(["*0: 0:04:00*"])
+    result.stdout.fnmatch_lines(["*1: 0:04:00*"])
+    # make sure that that we get a '0' exit code for the testsuite
+    assert result.ret == 0
+
+    # corresponding slice files, should exist
+    with open(testdir.tmpdir / "include_000.txt") as slice_file:
+        assert slice_file.read().splitlines() == [
+            "test_history_slices.py::test_should_pass_1",
+            "test_history_slices.py::test_should_pass_2",
+            "test_history_slices.py::test_should_pass_3",
+        ]
+
+    with open(testdir.tmpdir / "include_001.txt") as slice_file:
+        assert slice_file.read().splitlines() == [
+            "test_history_slices.py::test_with_history_data",
+            "test_history_slices.py::test_that_failed",
+        ]


### PR DESCRIPTION
This helps in able to split test between machines, to make a run of
a big suite of long running tests run in parallel.
it use the run history of the test from elasticsearch to create
"slice" files, with the specific tests, to fit a goal of how long
you want you run suite to be. (assuming you have enough capability
of spining as much machines you need, for example using jenkins
togther with AWS spot fleets)