### PR TITLE
fix: stringify excrepr before sending it to elasticsearch

### DIFF
--- a/pytest_elk_reporter.py
+++ b/pytest_elk_reporter.py
@@ -317,7 +317,7 @@ class ElkReporter(object):  # pylint: disable=too-many-instance-attributes
         test_data = dict(
             timestamp=datetime.datetime.utcnow().isoformat(),
             outcome="internal-error",
-            faiure_message=excrepr,
+            faiure_message=str(excrepr),
             **self.session_data
         )
         self.post_to_elasticsearch(test_data)


### PR DESCRIPTION
according to
https://docs.pytest.org/en/7.1.x/reference/reference.html#pytest.hookspec.pytest_internalerror, `excrepr` is an instance of `ReprExceptionInfo`, which cannot be JSON encoded, see
https://docs.python.org/3/library/json.html#py-to-json-table. but `ReprExceptionInfo` is derived from `ExceptionRepr`, which is in turn can be stringified using `str()`.

so, in this change, to send this internal error to elasticsearch, we convert it to a string using `str()`.

Refs https://github.com/scylladb/scylla-dtest/issues/4103
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>