### PR TITLE
Add support of reporting subtest

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,4 +7,5 @@ pytest-cov
 tox
 wheel>=0.33.0
 pytest-xdist
+pytest-subtests
 six


### PR DESCRIPTION
when one uses `pytest-subtests` plugin, this plugin was able to report only the last report from the test, which is passing always (if no setup/teardown issues, or failure outside of the context of subtests), and the subtest failure were lost and not counted/reported.

this change is fixing this, and collects all of the reports during a test and report them each on it's own.

this introduce a new field to the output of a test report, `subtest` if it's a report from subtest, it would be the message of that subtest.

Fixes: #28