### PR TITLE
use offset-aware datetime API

### DIFF
--- a/pytest_elk_reporter.py
+++ b/pytest_elk_reporter.py
@@ -296,7 +296,7 @@ class ElkReporter(object):  # pylint: disable=too-many-instance-attributes
         self.stats[outcome] += 1
         test_data = dict(
             item_report.user_properties,
-            timestamp=datetime.datetime.utcnow().isoformat(),
+            timestamp=datetime.datetime.now(tz=datetime.timezone.utc).isoformat(),
             name=item_report.nodeid,
             outcome=outcome,
             duration=item_report.duration,


### PR DESCRIPTION
it is distracting at seeing the warning like when running test:

```
  /home/kefu/.local/lib/python3.12/site-packages/pytest_elk_reporter.py:281: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    timestamp=datetime.datetime.utcnow().isoformat(),
```

so, in this change, let's switch to the offset-aware datetime API to silence this warning.